### PR TITLE
change hosts in publish-third-party-packages playbook

### DIFF
--- a/playbooks/publish-third-party-packages/post.yaml
+++ b/playbooks/publish-third-party-packages/post.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: builder
+- hosts: worker
   roles:
     - fetch-packages
 


### PR DESCRIPTION
change 'builder' to 'worker' due to nodeset changes